### PR TITLE
Changed option :raw to true as default.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
 1.6.2 (unreleased)
+  - Option :raw defaults to true. Expected behavior is that Objects are recursively formatted (Matt Martini)
   - Improves spec performance and simplicity (Mauro George)
   - Handle objects that have a custom #to_hash method (Elliot Shank)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,4 +79,5 @@ Special thanks goes to awesome team of contributors, namely:
 * Trevor Wennblom -- https://github.com/trevor
 * vfrride -- https://github.com/vfrride
 * Viktar Basharymau -- https://github.com/DNNX
+* Matt Martini -- https://github.com/mattmartini
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Default options:
 :html       => false,  # Use ANSI color codes rather than HTML.
 :multiline  => true,   # Display in multiple lines.
 :plain      => false,  # Use colors.
-:raw        => false,  # Do not recursively format object instance variables.
+:raw        => true,   # Recursively format object instance variables.
 :sort_keys  => false,  # Do not sort hash keys.
 :limit      => false,  # Limit large output for arrays and hashes. Set to a boolean or integer.
 :color => {

--- a/lib/awesome_print/ext/active_record.rb
+++ b/lib/awesome_print/ext/active_record.rb
@@ -31,11 +31,11 @@ module AwesomePrint
 
     # Format ActiveRecord instance object.
     #
-    # NOTE: by default only instance attributes (i.e. columns) are shown. To format
-    # ActiveRecord instance as regular object showing its instance variables and
-    # accessors use :raw => true option:
+    # NOTE: by default ActiveRecord instances are formatted as regular objects showing
+    # its instance variables and accessors.  To format with only instance attributes
+    # (i.e. columns) use :raw => false option:
     #
-    # ap record, :raw => true
+    # ap record, :raw => false
     #
     #------------------------------------------------------------------------------
     def awesome_active_record_instance(object)

--- a/lib/awesome_print/ext/mongo_mapper.rb
+++ b/lib/awesome_print/ext/mongo_mapper.rb
@@ -54,11 +54,11 @@ module AwesomePrint
 
     # Format MongoMapper instance object.
     #
-    # NOTE: by default only instance attributes (i.e. keys) are shown. To format
-    # MongoMapper instance as regular object showing its instance variables and
-    # accessors use :raw => true option:
+    # NOTE: by default MongoMapper instances are formatted as regular objects showing
+    # its instance variables and accessors.  To format with only instance attributes
+    # (i.e. keys) use :raw => false option:
     #
-    # ap record, :raw => true
+    # ap record, :raw => false
     #
     #------------------------------------------------------------------------------
     def awesome_mongo_mapper_instance(object)

--- a/lib/awesome_print/ext/ripple.rb
+++ b/lib/awesome_print/ext/ripple.rb
@@ -29,10 +29,11 @@ module AwesomePrint
 
     # Format Ripple instance object.
     #
-    # NOTE: by default only instance attributes are shown. To format a Ripple document instance
-    # as a regular object showing its instance variables and accessors use :raw => true option:
+    # NOTE: by default Ripple document instances are formatted as regular objects showing
+    # its instance variables and accessors.  To format with only instance attributes
+    # use :raw => false option:
     #
-    # ap document, :raw => true
+    # ap document, :raw => false
     #
     #------------------------------------------------------------------------------
     def awesome_ripple_document_instance(object)

--- a/lib/awesome_print/inspector.rb
+++ b/lib/awesome_print/inspector.rb
@@ -53,16 +53,16 @@ module AwesomePrint
     AP = :__awesome_print__
 
     def initialize(options = {})
-      @options = { 
+      @options = {
         :indent     => 4,      # Indent using 4 spaces.
         :index      => true,   # Display array indices.
         :html       => false,  # Use ANSI color codes rather than HTML.
         :multiline  => true,   # Display in multiple lines.
         :plain      => false,  # Use colors.
-        :raw        => false,  # Do not recursively format object instance variables.
+        :raw        => true,   # Recursively format object instance variables.
         :sort_keys  => false,  # Do not sort hash keys.
         :limit      => false,  # Limit large output for arrays and hashes. Set to a boolean or integer.
-        :color => { 
+        :color => {
           :args       => :pale,
           :array      => :white,
           :bigdecimal => :blue,
@@ -92,7 +92,7 @@ module AwesomePrint
       @formatter = AwesomePrint::Formatter.new(self)
       Thread.current[AP] ||= []
     end
-  
+
     # Dispatcher that detects data nesting and invokes object-aware formatter.
     #------------------------------------------------------------------------------
     def awesome(object)

--- a/spec/misc_spec.rb
+++ b/spec/misc_spec.rb
@@ -62,7 +62,7 @@ RSpec.describe "AwesomePrint" do
     it "IPAddr workaround" do
       require "ipaddr"
       ipaddr = IPAddr.new("3ffe:505:2::1")
-      expect(ipaddr.ai).to eq("#<IPAddr: IPv6:3ffe:0505:0002:0000:0000:0000:0000:0001/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>")
+      expect(ipaddr.ai(:raw => false)).to eq("#<IPAddr: IPv6:3ffe:0505:0002:0000:0000:0000:0000:0001/ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>")
     end
 
     # See https://github.com/michaeldv/awesome_print/issues/139


### PR DESCRIPTION
In response to Issue #190 AP upgrade loses functionality in displaying objects.
https://github.com/michaeldv/awesome_print/issues/190

Expected behavior is that Objects are recursively formatted.
The default setting is reversed to true.