### PR TITLE
check for the specific ActiveSupport method we need available

### DIFF
--- a/lib/awesome_print.rb
+++ b/lib/awesome_print.rb
@@ -25,7 +25,7 @@ unless defined?(AwesomePrint::Inspector)
   #
   # Load remaining extensions.
   #
-  if defined?(ActiveSupport)
+  if defined?(ActiveSupport.on_load)
     ActiveSupport.on_load(:action_view) do
       require File.dirname(__FILE__) + "/awesome_print/ext/action_view"
     end


### PR DESCRIPTION
I ran into an issue where a
require 'mail'
defines the ActiveSupport symbol, but without the on_load support, so I was getting an error loading your gem (which I love, thanks much! :) -- this fixed the issue.

Cheers,
Kem