### PR TITLE
Add more specific check for ActiveSupport.

### DIFF
--- a/lib/awesome_print.rb
+++ b/lib/awesome_print.rb
@@ -25,7 +25,7 @@ unless defined?(AwesomePrint::Inspector)
   #
   # Load remaining extensions.
   #
-  if defined?(ActiveSupport)
+  if defined?(ActiveSupport) && ActiveSupport.respond_to?(:on_load)
     ActiveSupport.on_load(:action_view) do
       require File.dirname(__FILE__) + "/awesome_print/ext/action_view"
     end


### PR DESCRIPTION
Just checking for ActiveSupport isn't enough. Some libraries
define the top level ActiveSupport module, that doesn't mean
that the classes you need to use exist.

See mikel/mail#816 for an example.