### PR TITLE
Don't require rake in gemspec

### DIFF
--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -3,7 +3,6 @@
 # Awesome Print is freely distributable under the terms of MIT license.
 # See LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
-require "rake"
 
 Gem::Specification.new do |s|
   s.name        = "awesome_print"


### PR DESCRIPTION
This can cause breakage when installing via bundler:

```console
$ bundle install --without development --path=${BUNDLE_PATH:-vendor/bundle}
Fetching https://github.com/michaeldv/awesome_print
There was a LoadError while loading awesome_print.gemspec: 
cannot load such file -- rake from
/home/travis/build/vendor/bundle/ruby/2.3.0/bundler/gems/awesome_print-d8aeb66b4b03/awesome_print.gemspec:6:in
`<main>'
Does it try to require a relative path? That's been removed in Ruby 1.9.
```
