### PR TITLE
Use aliases when available for Mongoid fields

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.6.2 (unreleased)
   - Improves spec performance and simplicity (Mauro George)
   - Handle objects that have a custom #to_hash method (Elliot Shank)
+  - Shows field aliases when available for Mongoid (Alexey Zapparov)
 
 1.6.1
   - Fixes specs on all rails dependencies (Mauro George)


### PR DESCRIPTION
Mongoid allows use short field names in real but call them with aliases:

``` ruby
    class User
      include Mongoid::Document

      field :e,  :as => :email
      field :bd, :as => :birth_date
    end
```

This patch changes output of `ap User` from:

``` ruby
    class User < Object {
       :_id => :"moped/bson/object_id",
        :bd => :object,
         :e => :object
    }
```

to:

``` ruby
    class User < Object {
               :id => :"moped/bson/object_id",
       :birth_date => :object,
            :email => :object
    }
```