### PR TITLE
Fixes michaeldv/awesome_print#218

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 1.6.2 (unreleased)
   - Improves spec performance and simplicity (Mauro George)
   - Handle objects that have a custom #to_hash method (Elliot Shank)
+  - Fixes development dependencies for environments without rake (Edgar Cabrera)
 
 1.6.1
   - Fixes specs on all rails dependencies (Mauro George)

--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -28,6 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'nokogiri', '>= 1.6.5'
   s.add_development_dependency 'codeclimate-test-reporter'
-  s.add_development_dependency 'bundler', '~> 1.11'
   s.add_development_dependency 'rake', '~> 10.0'
 end

--- a/awesome_print.gemspec
+++ b/awesome_print.gemspec
@@ -3,7 +3,6 @@
 # Awesome Print is freely distributable under the terms of MIT license.
 # See LICENSE file or http://www.opensource.org/licenses/mit-license.php
 #------------------------------------------------------------------------------
-require "rake"
 
 Gem::Specification.new do |s|
   s.name        = "awesome_print"
@@ -29,4 +28,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'nokogiri', '>= 1.6.5'
   s.add_development_dependency 'codeclimate-test-reporter'
+  s.add_development_dependency 'bundler', '~> 1.11'
+  s.add_development_dependency 'rake', '~> 10.0'
 end


### PR DESCRIPTION
Explicitly requires rake and bundle as developement
dependencies at awesme_print.gemspec, following
the convention used by the 'bundle gem' command.

Requiring rake at the top of the gemspec caused
an error in environments without rake installed, resulting
in a failed 'bundle install'.