### PR TITLE
Fix travis bundler failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ rvm:
   - 2.1
   - 2.2
 
+before_install:
+  - gem install bundler
+
 gemfile:
   - gemfiles/rails_3.2.gemfile
   - gemfiles/rails_4.0.gemfile


### PR DESCRIPTION
Currently a good portion of our builds are failing due to the following error

    NoMethodError: undefined method `spec' for nil:NilClass

Fix found here:
https://github.com/travis-ci/travis-ci/issues/5239#issuecomment-167355686