### PR TITLE
Fix Travis mime-types dependency issue

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -4,14 +4,26 @@ end
 
 appraise 'rails-4.0' do
   gem 'rails', '~> 4.0.0'
+
+  # The last version that doesn't need Ruby 2.0 and works with version 4.0 of
+  # Rails. This addresses a build problem with Travis for version 1.9.3 of Ruby
+  gem 'mime-types', '2.6.2', :platforms => :ruby_19
 end
 
 appraise 'rails-4.1' do
   gem 'rails', '~> 4.1.0'
+
+  # The last version that doesn't need Ruby 2.0 and works with version 4.1 of
+  # Rails. This addresses a build problem with Travis for version 1.9.3 of Ruby
+  gem 'mime-types', '2.6.2', :platforms => :ruby_19
 end
 
 appraise 'rails-4.2' do
   gem 'rails', '~> 4.2.0'
+
+  # The last version that doesn't need Ruby 2.0 and works with version 4.2 of
+  # Rails. This addresses a build problem with Travis for version 1.9.3 of Ruby
+  gem 'mime-types', '2.6.2', :platforms => :ruby_19
 end
 
 appraise 'mongoid-3.0' do

--- a/gemfiles/rails_4.0.gemfile
+++ b/gemfiles/rails_4.0.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.0.0"
+gem "mime-types", "2.6.2", :platforms => :ruby_19
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.1.gemfile
+++ b/gemfiles/rails_4.1.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.1.0"
+gem "mime-types", "2.6.2", :platforms => :ruby_19
 
 gemspec :path => "../"

--- a/gemfiles/rails_4.2.gemfile
+++ b/gemfiles/rails_4.2.gemfile
@@ -3,5 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.0"
+gem "mime-types", "2.6.2", :platforms => :ruby_19
 
 gemspec :path => "../"


### PR DESCRIPTION
Before this fix some of our Travis builds failed (during the gem install
stage) with:

    Gem::InstallError: mime-types-data requires Ruby version >= 2.0.

Idea for the fix was found here:
https://github.com/sgruhier/foundation_rails_helper/pull/116
Although we could not use the same method as I only want to lock
down the version of mime-type where necessary. Also trying to lock
the version to 2.6.2 would break our Rails-3.2 Appraisal path.

Before (on the main repo):
![screen shot 2016-05-06 at 4 14 02 pm](https://cloud.githubusercontent.com/assets/71481/15065710/b745a80a-13a5-11e6-9462-5b1cbb2a1440.png)

After (on my fork):
![screen shot 2016-05-06 at 4 14 39 pm](https://cloud.githubusercontent.com/assets/71481/15065713/be351150-13a5-11e6-93aa-b11b1bed869f.png)

Note: The error seen in 22.4 was already failing it's just that it was hidden by the gem installation breaking.