### PR TITLE
Fix travis active record specs

### DIFF
--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -17,9 +17,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
     end
 
     it "display single record" do
-      out = @ap.send(:awesome, @diana)
+      out = @ap.awesome(@diana)
       str = <<-EOS.strip
-#<User:0x01234567> {
+#<User:placeholder_id> {
          :admin => false,
     :created_at => ?,
             :id => nil,
@@ -32,21 +32,21 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
       else
         str.sub!('?', '1992-10-10 12:30:00 UTC')
       end
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
     end
 
     it "display multiple records" do
-      out = @ap.send(:awesome, [ @diana, @laura ])
+      out = @ap.awesome([ @diana, @laura ])
       str = <<-EOS.strip
 [
-    [0] #<User:0x01234567> {
+    [0] #<User:placeholder_id> {
              :admin => false,
         :created_at => ??,
                 :id => nil,
               :name => "Diana",
               :rank => 1
     },
-    [1] #<User:0x01234567> {
+    [1] #<User:placeholder_id> {
              :admin => true,
         :created_at => ?!,
                 :id => nil,
@@ -62,23 +62,23 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         str.sub!('??', '1992-10-10 12:30:00 UTC')
         str.sub!('?!', '2003-05-26 14:15:00 UTC')
       end
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
     end
 
     it "display multiple records on a relation" do
       @diana.save
       @laura.save
-      out = @ap.send(:awesome, User.all)
+      out = @ap.awesome(User.all)
       str = <<-EOS.strip
 [
-    [0] #<User:0x01234567> {
+    [0] #<User:placeholder_id> {
              :admin => false,
         :created_at => ??,
                 :id => 1,
               :name => "Diana",
               :rank => 1
     },
-    [1] #<User:0x01234567> {
+    [1] #<User:placeholder_id> {
              :admin => true,
         :created_at => ?!,
                 :id => 2,
@@ -94,7 +94,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         str.sub!('??', '1992-10-10 12:30:00 UTC')
         str.sub!('?!', '2003-05-26 14:15:00 UTC')
       end
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
     end
   end
 
@@ -108,12 +108,12 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
     end
 
     it "display single record" do
-      out = @ap.send(:awesome, @diana)
+      out = @ap.awesome(@diana)
 
       if activerecord_4_2?
         if RUBY_VERSION > '1.9.3'
           str = <<-EOS.strip
-#<User:0x01234567
+#<User:placeholder_id
     @_start_transaction_state = {},
     @aggregation_cache = {},
     @destroyed = false,
@@ -131,13 +131,13 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
     ],
     @transaction_state = nil,
     @txn = nil,
-    attr_accessor :attributes = #<ActiveRecord::AttributeSet:0x01234567
-        @attributes = #<ActiveRecord::LazyAttributeHash:0x01234567
+    attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
+        @attributes = #<ActiveRecord::LazyAttributeHash:placeholder_id
             @additional_types = {},
             @delegate_hash = {
-                     "admin" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                     "admin" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "admin",
-                    attr_reader :type = #<ActiveRecord::Type::Boolean:0x01234567
+                    attr_reader :type = #<ActiveRecord::Type::Boolean:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -145,9 +145,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = false,
                     attr_reader :value_before_type_cast = false
                 >,
-                "created_at" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                "created_at" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "created_at",
-                    attr_reader :type = #<ActiveRecord::Type::DateTime:0x01234567
+                    attr_reader :type = #<ActiveRecord::Type::DateTime:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -155,9 +155,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = 1992-10-10 12:30:00 UTC,
                     attr_reader :value_before_type_cast = "1992-10-10 12:30:00"
                 >,
-                        "id" => #<ActiveRecord::Attribute::FromDatabase:0x01234567
+                        "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
                     attr_reader :name = "id",
-                    attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                    attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                         @range = -2147483648...2147483648,
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
@@ -166,9 +166,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = nil,
                     attr_reader :value_before_type_cast = nil
                 >,
-                      "name" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                      "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "name",
-                    attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                    attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -176,9 +176,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = "Diana",
                     attr_reader :value_before_type_cast = "Diana"
                 >,
-                      "rank" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                      "rank" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "rank",
-                    attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                    attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                         @range = -2147483648...2147483648,
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
@@ -190,28 +190,28 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             },
             @materialized = false,
             @types = {
-                     "admin" => #<ActiveRecord::Type::Boolean:0x01234567
+                     "admin" => #<ActiveRecord::Type::Boolean:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
                 >,
-                "created_at" => #<ActiveRecord::Type::DateTime:0x01234567
+                "created_at" => #<ActiveRecord::Type::DateTime:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
                 >,
-                        "id" => #<ActiveRecord::Type::Integer:0x01234567
+                        "id" => #<ActiveRecord::Type::Integer:placeholder_id
                     @range = -2147483648...2147483648,
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
                 >,
-                      "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                      "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
                 >,
-                      "rank" => #<ActiveRecord::Type::Integer:0x01234567
+                      "rank" => #<ActiveRecord::Type::Integer:placeholder_id
                     @range = -2147483648...2147483648,
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
@@ -239,7 +239,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
           EOS
         else
           str = <<-EOS.strip
-#<User:0x01234567
+#<User:placeholder_id
     @_start_transaction_state = {},
     @aggregation_cache = {},
     @destroyed = false,
@@ -257,14 +257,14 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
     ],
     @transaction_state = nil,
     @txn = nil,
-    attr_accessor :attributes = #<ActiveRecord::AttributeSet:0x01234567
-        attr_reader :attributes = #<ActiveRecord::LazyAttributeHash:0x01234567
+    attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
+        attr_reader :attributes = #<ActiveRecord::LazyAttributeHash:placeholder_id
             @materialized = false,
             attr_reader :additional_types = {},
             attr_reader :delegate_hash = {
-                     "admin" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                     "admin" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "admin",
-                    attr_reader :type = #<ActiveRecord::Type::Boolean:0x01234567
+                    attr_reader :type = #<ActiveRecord::Type::Boolean:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -272,9 +272,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = false,
                     attr_reader :value_before_type_cast = false
                 >,
-                "created_at" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                "created_at" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "created_at",
-                    attr_reader :type = #<ActiveRecord::Type::DateTime:0x01234567
+                    attr_reader :type = #<ActiveRecord::Type::DateTime:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -282,9 +282,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = 1992-10-10 12:30:00 UTC,
                     attr_reader :value_before_type_cast = "1992-10-10 12:30:00"
                 >,
-                        "id" => #<ActiveRecord::Attribute::FromDatabase:0x01234567
+                        "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
                     attr_reader :name = "id",
-                    attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                    attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :range = -2147483648...2147483648,
@@ -293,9 +293,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = nil,
                     attr_reader :value_before_type_cast = nil
                 >,
-                      "name" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                      "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "name",
-                    attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                    attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -303,9 +303,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = "Diana",
                     attr_reader :value_before_type_cast = "Diana"
                 >,
-                      "rank" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                      "rank" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "rank",
-                    attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                    attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :range = -2147483648...2147483648,
@@ -316,28 +316,28 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 >
             },
             attr_reader :types = {
-                     "admin" => #<ActiveRecord::Type::Boolean:0x01234567
+                     "admin" => #<ActiveRecord::Type::Boolean:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
                 >,
-                "created_at" => #<ActiveRecord::Type::DateTime:0x01234567
+                "created_at" => #<ActiveRecord::Type::DateTime:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
                 >,
-                        "id" => #<ActiveRecord::Type::Integer:0x01234567
+                        "id" => #<ActiveRecord::Type::Integer:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :range = -2147483648...2147483648,
                     attr_reader :scale = nil
                 >,
-                      "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                      "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
                 >,
-                      "rank" => #<ActiveRecord::Type::Integer:0x01234567
+                      "rank" => #<ActiveRecord::Type::Integer:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :range = -2147483648...2147483648,
@@ -366,12 +366,12 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         end
       elsif activerecord_4_1?
         str = <<-EOS.strip
-#<User:0x01234567
+#<User:placeholder_id
     @_start_transaction_state = {},
     @aggregation_cache = {},
     @attributes_cache = {},
     @column_types = {
-             "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+             "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = false,
             attr_reader :default = nil,
@@ -384,7 +384,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             attr_reader :sql_type = "boolean",
             attr_reader :type = :boolean
         >,
-        "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+        "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = false,
             attr_reader :default = nil,
@@ -397,7 +397,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             attr_reader :sql_type = "datetime",
             attr_reader :type = :datetime
         >,
-                "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = true,
             attr_reader :default = nil,
@@ -410,7 +410,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             attr_reader :sql_type = "INTEGER",
             attr_reader :type = :integer
         >,
-              "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+              "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = false,
             attr_reader :default = nil,
@@ -423,7 +423,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             attr_reader :sql_type = "varchar(255)",
             attr_reader :type = :string
         >,
-              "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+              "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = false,
             attr_reader :default = nil,
@@ -466,12 +466,12 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         EOS
       elsif activerecord_4_0?
         str = <<-EOS.strip
- #<User:0x01234567
+ #<User:placeholder_id
     @_start_transaction_state = {},
     @aggregation_cache = {},
     @attributes_cache = {},
     @column_types = {
-             "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+             "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = false,
             attr_reader :default = nil,
@@ -484,7 +484,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             attr_reader :sql_type = "boolean",
             attr_reader :type = :boolean
         >,
-        "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+        "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = false,
             attr_reader :default = nil,
@@ -497,7 +497,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             attr_reader :sql_type = "datetime",
             attr_reader :type = :datetime
         >,
-                "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = true,
             attr_reader :default = nil,
@@ -510,7 +510,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             attr_reader :sql_type = "INTEGER",
             attr_reader :type = :integer
         >,
-              "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+              "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = false,
             attr_reader :default = nil,
@@ -523,7 +523,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
             attr_reader :sql_type = "varchar(255)",
             attr_reader :type = :string
         >,
-              "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+              "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
             attr_accessor :coder = nil,
             attr_accessor :primary = false,
             attr_reader :default = nil,
@@ -568,7 +568,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
       elsif activerecord_3_2?
         if RUBY_VERSION > '1.9.3'
           str = <<-EOS.strip
-#<User:0x01234567
+#<User:placeholder_id
     @aggregation_cache = {},
     @attributes_cache = {},
     @destroyed = false,
@@ -595,7 +595,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
           EOS
         else
           str = <<-EOS.strip
-#<User:0x01234567
+#<User:placeholder_id
     @aggregation_cache = {},
     @attributes_cache = {},
     @destroyed = false,
@@ -623,17 +623,17 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         end
       end
       str.sub!('?', '1992-10-10 12:30:00')
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
     end
 
     it "display multiple records" do
-      out = @ap.send(:awesome, [ @diana, @laura ])
+      out = @ap.awesome([ @diana, @laura ])
 
       if activerecord_4_2?
         if RUBY_VERSION > '1.9.3'
           str = <<-EOS.strip
 [
-    [0] #<User:0x01234567
+    [0] #<User:placeholder_id
         @_start_transaction_state = {},
         @aggregation_cache = {},
         @destroyed = false,
@@ -651,13 +651,13 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         ],
         @transaction_state = nil,
         @txn = nil,
-        attr_accessor :attributes = #<ActiveRecord::AttributeSet:0x01234567
-            @attributes = #<ActiveRecord::LazyAttributeHash:0x01234567
+        attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
+            @attributes = #<ActiveRecord::LazyAttributeHash:placeholder_id
                 @additional_types = {},
                 @delegate_hash = {
-                         "admin" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                         "admin" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "admin",
-                        attr_reader :type = #<ActiveRecord::Type::Boolean:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Boolean:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -665,9 +665,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = false,
                         attr_reader :value_before_type_cast = false
                     >,
-                    "created_at" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                    "created_at" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "created_at",
-                        attr_reader :type = #<ActiveRecord::Type::DateTime:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::DateTime:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -675,9 +675,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = 1992-10-10 12:30:00 UTC,
                         attr_reader :value_before_type_cast = "1992-10-10 12:30:00"
                     >,
-                            "id" => #<ActiveRecord::Attribute::FromDatabase:0x01234567
+                            "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
                         attr_reader :name = "id",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                             @range = -2147483648...2147483648,
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
@@ -686,9 +686,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = nil,
                         attr_reader :value_before_type_cast = nil
                     >,
-                          "name" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                          "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "name",
-                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -696,9 +696,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = "Diana",
                         attr_reader :value_before_type_cast = "Diana"
                     >,
-                          "rank" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                          "rank" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "rank",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                             @range = -2147483648...2147483648,
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
@@ -710,28 +710,28 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 },
                 @materialized = false,
                 @types = {
-                         "admin" => #<ActiveRecord::Type::Boolean:0x01234567
+                         "admin" => #<ActiveRecord::Type::Boolean:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                    "created_at" => #<ActiveRecord::Type::DateTime:0x01234567
+                    "created_at" => #<ActiveRecord::Type::DateTime:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                            "id" => #<ActiveRecord::Type::Integer:0x01234567
+                            "id" => #<ActiveRecord::Type::Integer:placeholder_id
                         @range = -2147483648...2147483648,
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                          "rank" => #<ActiveRecord::Type::Integer:0x01234567
+                          "rank" => #<ActiveRecord::Type::Integer:placeholder_id
                         @range = -2147483648...2147483648,
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
@@ -756,7 +756,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => nil
         }
     >,
-    [1] #<User:0x01234567
+    [1] #<User:placeholder_id
         @_start_transaction_state = {},
         @aggregation_cache = {},
         @destroyed = false,
@@ -774,13 +774,13 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         ],
         @transaction_state = nil,
         @txn = nil,
-        attr_accessor :attributes = #<ActiveRecord::AttributeSet:0x01234567
-            @attributes = #<ActiveRecord::LazyAttributeHash:0x01234567
+        attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
+            @attributes = #<ActiveRecord::LazyAttributeHash:placeholder_id
                 @additional_types = {},
                 @delegate_hash = {
-                         "admin" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                         "admin" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "admin",
-                        attr_reader :type = #<ActiveRecord::Type::Boolean:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Boolean:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -788,9 +788,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = true,
                         attr_reader :value_before_type_cast = true
                     >,
-                    "created_at" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                    "created_at" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "created_at",
-                        attr_reader :type = #<ActiveRecord::Type::DateTime:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::DateTime:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -798,9 +798,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = 2003-05-26 14:15:00 UTC,
                         attr_reader :value_before_type_cast = "2003-05-26 14:15:00"
                     >,
-                            "id" => #<ActiveRecord::Attribute::FromDatabase:0x01234567
+                            "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
                         attr_reader :name = "id",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                             @range = -2147483648...2147483648,
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
@@ -809,9 +809,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = nil,
                         attr_reader :value_before_type_cast = nil
                     >,
-                          "name" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                          "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "name",
-                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -819,9 +819,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = "Laura",
                         attr_reader :value_before_type_cast = "Laura"
                     >,
-                          "rank" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                          "rank" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "rank",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                             @range = -2147483648...2147483648,
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
@@ -833,28 +833,28 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 },
                 @materialized = false,
                 @types = {
-                         "admin" => #<ActiveRecord::Type::Boolean:0x01234567
+                         "admin" => #<ActiveRecord::Type::Boolean:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                    "created_at" => #<ActiveRecord::Type::DateTime:0x01234567
+                    "created_at" => #<ActiveRecord::Type::DateTime:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                            "id" => #<ActiveRecord::Type::Integer:0x01234567
+                            "id" => #<ActiveRecord::Type::Integer:placeholder_id
                         @range = -2147483648...2147483648,
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                          "rank" => #<ActiveRecord::Type::Integer:0x01234567
+                          "rank" => #<ActiveRecord::Type::Integer:placeholder_id
                         @range = -2147483648...2147483648,
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
@@ -884,7 +884,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         else
           str = <<-EOS.strip
 [
-    [0] #<User:0x01234567
+    [0] #<User:placeholder_id
         @_start_transaction_state = {},
         @aggregation_cache = {},
         @destroyed = false,
@@ -902,14 +902,14 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         ],
         @transaction_state = nil,
         @txn = nil,
-        attr_accessor :attributes = #<ActiveRecord::AttributeSet:0x01234567
-            attr_reader :attributes = #<ActiveRecord::LazyAttributeHash:0x01234567
+        attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
+            attr_reader :attributes = #<ActiveRecord::LazyAttributeHash:placeholder_id
                 @materialized = false,
                 attr_reader :additional_types = {},
                 attr_reader :delegate_hash = {
-                         "admin" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                         "admin" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "admin",
-                        attr_reader :type = #<ActiveRecord::Type::Boolean:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Boolean:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -917,9 +917,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = false,
                         attr_reader :value_before_type_cast = false
                     >,
-                    "created_at" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                    "created_at" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "created_at",
-                        attr_reader :type = #<ActiveRecord::Type::DateTime:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::DateTime:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -927,9 +927,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = 1992-10-10 12:30:00 UTC,
                         attr_reader :value_before_type_cast = "1992-10-10 12:30:00"
                     >,
-                            "id" => #<ActiveRecord::Attribute::FromDatabase:0x01234567
+                            "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
                         attr_reader :name = "id",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :range = -2147483648...2147483648,
@@ -938,9 +938,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = nil,
                         attr_reader :value_before_type_cast = nil
                     >,
-                          "name" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                          "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "name",
-                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -948,9 +948,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = "Diana",
                         attr_reader :value_before_type_cast = "Diana"
                     >,
-                          "rank" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                          "rank" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "rank",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :range = -2147483648...2147483648,
@@ -961,28 +961,28 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     >
                 },
                 attr_reader :types = {
-                         "admin" => #<ActiveRecord::Type::Boolean:0x01234567
+                         "admin" => #<ActiveRecord::Type::Boolean:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                    "created_at" => #<ActiveRecord::Type::DateTime:0x01234567
+                    "created_at" => #<ActiveRecord::Type::DateTime:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                            "id" => #<ActiveRecord::Type::Integer:0x01234567
+                            "id" => #<ActiveRecord::Type::Integer:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :range = -2147483648...2147483648,
                         attr_reader :scale = nil
                     >,
-                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                          "rank" => #<ActiveRecord::Type::Integer:0x01234567
+                          "rank" => #<ActiveRecord::Type::Integer:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :range = -2147483648...2147483648,
@@ -1007,7 +1007,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => nil
         }
     >,
-    [1] #<User:0x01234567
+    [1] #<User:placeholder_id
         @_start_transaction_state = {},
         @aggregation_cache = {},
         @destroyed = false,
@@ -1025,14 +1025,14 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         ],
         @transaction_state = nil,
         @txn = nil,
-        attr_accessor :attributes = #<ActiveRecord::AttributeSet:0x01234567
-            attr_reader :attributes = #<ActiveRecord::LazyAttributeHash:0x01234567
+        attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
+            attr_reader :attributes = #<ActiveRecord::LazyAttributeHash:placeholder_id
                 @materialized = false,
                 attr_reader :additional_types = {},
                 attr_reader :delegate_hash = {
-                         "admin" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                         "admin" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "admin",
-                        attr_reader :type = #<ActiveRecord::Type::Boolean:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Boolean:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -1040,9 +1040,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = true,
                         attr_reader :value_before_type_cast = true
                     >,
-                    "created_at" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                    "created_at" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "created_at",
-                        attr_reader :type = #<ActiveRecord::Type::DateTime:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::DateTime:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -1050,9 +1050,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = 2003-05-26 14:15:00 UTC,
                         attr_reader :value_before_type_cast = "2003-05-26 14:15:00"
                     >,
-                            "id" => #<ActiveRecord::Attribute::FromDatabase:0x01234567
+                            "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
                         attr_reader :name = "id",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :range = -2147483648...2147483648,
@@ -1061,9 +1061,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = nil,
                         attr_reader :value_before_type_cast = nil
                     >,
-                          "name" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                          "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "name",
-                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -1071,9 +1071,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = "Laura",
                         attr_reader :value_before_type_cast = "Laura"
                     >,
-                          "rank" => #<ActiveRecord::Attribute::FromUser:0x01234567
+                          "rank" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "rank",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:0x01234567
+                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :range = -2147483648...2147483648,
@@ -1084,28 +1084,28 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     >
                 },
                 attr_reader :types = {
-                         "admin" => #<ActiveRecord::Type::Boolean:0x01234567
+                         "admin" => #<ActiveRecord::Type::Boolean:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                    "created_at" => #<ActiveRecord::Type::DateTime:0x01234567
+                    "created_at" => #<ActiveRecord::Type::DateTime:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                            "id" => #<ActiveRecord::Type::Integer:0x01234567
+                            "id" => #<ActiveRecord::Type::Integer:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :range = -2147483648...2147483648,
                         attr_reader :scale = nil
                     >,
-                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:0x01234567
+                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                          "rank" => #<ActiveRecord::Type::Integer:0x01234567
+                          "rank" => #<ActiveRecord::Type::Integer:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :range = -2147483648...2147483648,
@@ -1136,12 +1136,12 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
       elsif activerecord_4_1?
         str = <<-EOS.strip
 [
-    [0] #<User:0x01234567
+    [0] #<User:placeholder_id
         @_start_transaction_state = {},
         @aggregation_cache = {},
         @attributes_cache = {},
         @column_types = {
-                 "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                 "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1154,7 +1154,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "boolean",
                 attr_reader :type = :boolean
             >,
-            "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+            "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1167,7 +1167,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "datetime",
                 attr_reader :type = :datetime
             >,
-                    "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                    "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = true,
                 attr_reader :default = nil,
@@ -1180,7 +1180,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "INTEGER",
                 attr_reader :type = :integer
             >,
-                  "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                  "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1193,7 +1193,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "varchar(255)",
                 attr_reader :type = :string
             >,
-                  "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                  "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1233,12 +1233,12 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => nil
         }
     >,
-    [1] #<User:0x01234567
+    [1] #<User:placeholder_id
         @_start_transaction_state = {},
         @aggregation_cache = {},
         @attributes_cache = {},
         @column_types = {
-                 "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                 "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1251,7 +1251,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "boolean",
                 attr_reader :type = :boolean
             >,
-            "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+            "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1264,7 +1264,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "datetime",
                 attr_reader :type = :datetime
             >,
-                    "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                    "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = true,
                 attr_reader :default = nil,
@@ -1277,7 +1277,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "INTEGER",
                 attr_reader :type = :integer
             >,
-                  "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                  "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1290,7 +1290,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "varchar(255)",
                 attr_reader :type = :string
             >,
-                  "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                  "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1335,12 +1335,12 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
       elsif activerecord_4_0?
         str = <<-EOS.strip
 [
-    [0] #<User:0x01234567
+    [0] #<User:placeholder_id
         @_start_transaction_state = {},
         @aggregation_cache = {},
         @attributes_cache = {},
         @column_types = {
-                 "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                 "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1353,7 +1353,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "boolean",
                 attr_reader :type = :boolean
             >,
-            "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+            "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1366,7 +1366,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "datetime",
                 attr_reader :type = :datetime
             >,
-                    "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                    "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = true,
                 attr_reader :default = nil,
@@ -1379,7 +1379,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "INTEGER",
                 attr_reader :type = :integer
             >,
-                  "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                  "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1392,7 +1392,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "varchar(255)",
                 attr_reader :type = :string
             >,
-                  "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                  "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1433,12 +1433,12 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => nil
         }
     >,
-    [1] #<User:0x01234567
+    [1] #<User:placeholder_id
         @_start_transaction_state = {},
         @aggregation_cache = {},
         @attributes_cache = {},
         @column_types = {
-                 "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                 "admin" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1451,7 +1451,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "boolean",
                 attr_reader :type = :boolean
             >,
-            "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+            "created_at" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1464,7 +1464,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "datetime",
                 attr_reader :type = :datetime
             >,
-                    "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                    "id" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = true,
                 attr_reader :default = nil,
@@ -1477,7 +1477,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "INTEGER",
                 attr_reader :type = :integer
             >,
-                  "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                  "name" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1490,7 +1490,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                 attr_reader :sql_type = "varchar(255)",
                 attr_reader :type = :string
             >,
-                  "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:0x01234567
+                  "rank" => #<ActiveRecord::ConnectionAdapters::SQLite3Column:placeholder_id
                 attr_accessor :coder = nil,
                 attr_accessor :primary = false,
                 attr_reader :default = nil,
@@ -1537,7 +1537,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         if RUBY_VERSION > '1.9.3'
           str = <<-EOS.strip
 [
-    [0] #<User:0x01234567
+    [0] #<User:placeholder_id
         @aggregation_cache = {},
         @attributes_cache = {},
         @destroyed = false,
@@ -1561,7 +1561,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => nil
         }
     >,
-    [1] #<User:0x01234567
+    [1] #<User:placeholder_id
         @aggregation_cache = {},
         @attributes_cache = {},
         @destroyed = false,
@@ -1590,7 +1590,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         else
           str = <<-EOS.strip
 [
-    [0] #<User:0x01234567
+    [0] #<User:placeholder_id
         @aggregation_cache = {},
         @attributes_cache = {},
         @destroyed = false,
@@ -1614,7 +1614,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
         },
         attr_reader :mass_assignment_options = nil
     >,
-    [1] #<User:0x01234567
+    [1] #<User:placeholder_id
         @aggregation_cache = {},
         @attributes_cache = {},
         @destroyed = false,
@@ -1644,7 +1644,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
       end
       str.sub!('?', '1992-10-10 12:30:00')
       str.sub!('?', '2003-05-26 14:15:00')
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
     end
   end
 
@@ -1655,7 +1655,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
     end
 
     it "should print the class" do
-      expect(@ap.send(:awesome, User)).to eq <<-EOS.strip
+      expect(@ap.awesome(User)).to eq <<-EOS.strip
 class User < ActiveRecord::Base {
             :id => :integer,
           :name => :string,
@@ -1667,7 +1667,7 @@ class User < ActiveRecord::Base {
     end
 
     it "should print the class for non-direct subclasses of ActiveRecord::Base" do
-      out = @ap.send(:awesome, SubUser)
+      out = @ap.awesome(SubUser)
       expect(out).to eq <<-EOS.strip
 class SubUser < User {
             :id => :integer,
@@ -1680,7 +1680,7 @@ class SubUser < User {
     end
 
     it "should print ActiveRecord::Base objects (ex. ancestors)" do
-      expect { @ap.send(:awesome, User.ancestors) }.not_to raise_error
+      expect { @ap.awesome(User.ancestors) }.not_to raise_error
     end
   end
 
@@ -1692,7 +1692,7 @@ class SubUser < User {
 
     it "should format class methods properly" do
       # spec 1
-      out = @ap.send(:awesome, User.methods.grep(/first/))
+      out = @ap.awesome(User.methods.grep(/first/))
 
       if ActiveRecord::VERSION::STRING >= "3.2"
         if RUBY_VERSION >= "1.9"
@@ -1705,11 +1705,11 @@ class SubUser < User {
       end
 
       # spec 2
-      out = @ap.send(:awesome, User.methods.grep(/primary_key/))
+      out = @ap.awesome(User.methods.grep(/primary_key/))
       expect(out).to match(/\sprimary_key\(.*?\)\s+Class \(ActiveRecord::AttributeMethods::PrimaryKey::ClassMethods\)/)
 
       # spec 3
-      out = @ap.send(:awesome, User.methods.grep(/validate/))
+      out = @ap.awesome(User.methods.grep(/validate/))
 
       if ActiveRecord::VERSION::MAJOR < 3
         expect(out).to match(/\svalidate\(\*arg.*?\)\s+User \(ActiveRecord::Base\)/)

--- a/spec/ext/active_record_spec.rb
+++ b/spec/ext/active_record_spec.rb
@@ -126,9 +126,6 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
               "rank" => 1
     },
     @readonly = false,
-    @reflects_state = [
-        [0] false
-    ],
     @transaction_state = nil,
     @txn = nil,
     attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
@@ -155,20 +152,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = 1992-10-10 12:30:00 UTC,
                     attr_reader :value_before_type_cast = "1992-10-10 12:30:00"
                 >,
-                        "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
-                    attr_reader :name = "id",
-                    attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
-                        @range = -2147483648...2147483648,
-                        attr_reader :limit = nil,
-                        attr_reader :precision = nil,
-                        attr_reader :scale = nil
-                    >,
-                    attr_reader :value = nil,
-                    attr_reader :value_before_type_cast = nil
-                >,
                       "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "name",
-                    attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                    attr_reader :type = #<ActiveRecord::Type::String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -206,7 +192,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
                 >,
-                      "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                      "name" => #<ActiveRecord::Type::String:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
@@ -252,9 +238,6 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
               "rank" => 1
     },
     @readonly = false,
-    @reflects_state = [
-        [0] false
-    ],
     @transaction_state = nil,
     @txn = nil,
     attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
@@ -282,20 +265,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :value = 1992-10-10 12:30:00 UTC,
                     attr_reader :value_before_type_cast = "1992-10-10 12:30:00"
                 >,
-                        "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
-                    attr_reader :name = "id",
-                    attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
-                        attr_reader :limit = nil,
-                        attr_reader :precision = nil,
-                        attr_reader :range = -2147483648...2147483648,
-                        attr_reader :scale = nil
-                    >,
-                    attr_reader :value = nil,
-                    attr_reader :value_before_type_cast = nil
-                >,
                       "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                     attr_reader :name = "name",
-                    attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                    attr_reader :type = #<ActiveRecord::Type::String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -332,7 +304,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                     attr_reader :range = -2147483648...2147483648,
                     attr_reader :scale = nil
                 >,
-                      "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                      "name" => #<ActiveRecord::Type::String:placeholder_id
                     attr_reader :limit = nil,
                     attr_reader :precision = nil,
                     attr_reader :scale = nil
@@ -646,9 +618,6 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => 1
         },
         @readonly = false,
-        @reflects_state = [
-            [0] false
-        ],
         @transaction_state = nil,
         @txn = nil,
         attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
@@ -675,20 +644,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = 1992-10-10 12:30:00 UTC,
                         attr_reader :value_before_type_cast = "1992-10-10 12:30:00"
                     >,
-                            "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
-                        attr_reader :name = "id",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
-                            @range = -2147483648...2147483648,
-                            attr_reader :limit = nil,
-                            attr_reader :precision = nil,
-                            attr_reader :scale = nil
-                        >,
-                        attr_reader :value = nil,
-                        attr_reader :value_before_type_cast = nil
-                    >,
                           "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "name",
-                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                        attr_reader :type = #<ActiveRecord::Type::String:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -726,7 +684,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                          "name" => #<ActiveRecord::Type::String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -769,9 +727,6 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => 2
         },
         @readonly = false,
-        @reflects_state = [
-            [0] false
-        ],
         @transaction_state = nil,
         @txn = nil,
         attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
@@ -798,20 +753,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = 2003-05-26 14:15:00 UTC,
                         attr_reader :value_before_type_cast = "2003-05-26 14:15:00"
                     >,
-                            "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
-                        attr_reader :name = "id",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
-                            @range = -2147483648...2147483648,
-                            attr_reader :limit = nil,
-                            attr_reader :precision = nil,
-                            attr_reader :scale = nil
-                        >,
-                        attr_reader :value = nil,
-                        attr_reader :value_before_type_cast = nil
-                    >,
                           "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "name",
-                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                        attr_reader :type = #<ActiveRecord::Type::String:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -849,7 +793,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
                     >,
-                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                          "name" => #<ActiveRecord::Type::String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -897,9 +841,6 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => 1
         },
         @readonly = false,
-        @reflects_state = [
-            [0] false
-        ],
         @transaction_state = nil,
         @txn = nil,
         attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
@@ -927,20 +868,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = 1992-10-10 12:30:00 UTC,
                         attr_reader :value_before_type_cast = "1992-10-10 12:30:00"
                     >,
-                            "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
-                        attr_reader :name = "id",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
-                            attr_reader :limit = nil,
-                            attr_reader :precision = nil,
-                            attr_reader :range = -2147483648...2147483648,
-                            attr_reader :scale = nil
-                        >,
-                        attr_reader :value = nil,
-                        attr_reader :value_before_type_cast = nil
-                    >,
                           "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "name",
-                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                        attr_reader :type = #<ActiveRecord::Type::String:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -977,7 +907,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :range = -2147483648...2147483648,
                         attr_reader :scale = nil
                     >,
-                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                          "name" => #<ActiveRecord::Type::String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil
@@ -1020,9 +950,6 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                   "rank" => 2
         },
         @readonly = false,
-        @reflects_state = [
-            [0] false
-        ],
         @transaction_state = nil,
         @txn = nil,
         attr_accessor :attributes = #<ActiveRecord::AttributeSet:placeholder_id
@@ -1050,20 +977,9 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :value = 2003-05-26 14:15:00 UTC,
                         attr_reader :value_before_type_cast = "2003-05-26 14:15:00"
                     >,
-                            "id" => #<ActiveRecord::Attribute::FromDatabase:placeholder_id
-                        attr_reader :name = "id",
-                        attr_reader :type = #<ActiveRecord::Type::Integer:placeholder_id
-                            attr_reader :limit = nil,
-                            attr_reader :precision = nil,
-                            attr_reader :range = -2147483648...2147483648,
-                            attr_reader :scale = nil
-                        >,
-                        attr_reader :value = nil,
-                        attr_reader :value_before_type_cast = nil
-                    >,
                           "name" => #<ActiveRecord::Attribute::FromUser:placeholder_id
                         attr_reader :name = "name",
-                        attr_reader :type = #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                        attr_reader :type = #<ActiveRecord::Type::String:placeholder_id
                             attr_reader :limit = nil,
                             attr_reader :precision = nil,
                             attr_reader :scale = nil
@@ -1100,7 +1016,7 @@ RSpec.describe "AwesomePrint/ActiveRecord", skip: ->{ !ExtVerifier.has_rails? }.
                         attr_reader :range = -2147483648...2147483648,
                         attr_reader :scale = nil
                     >,
-                          "name" => #<ActiveRecord::ConnectionAdapters::SQLite3String:placeholder_id
+                          "name" => #<ActiveRecord::Type::String:placeholder_id
                         attr_reader :limit = nil,
                         attr_reader :precision = nil,
                         attr_reader :scale = nil

--- a/spec/ext/mongo_mapper_spec.rb
+++ b/spec/ext/mongo_mapper_spec.rb
@@ -36,9 +36,9 @@ RSpec.describe "AwesomePrint/MongoMapper", skip: ->{ !ExtVerifier.has_mongo_mapp
 
       if MongoMapper::Version >= "0.13"
         str = <<-EOS.strip
-#<MongoUser:0x01234567
+#<MongoUser:placeholder_id
     @__mm_default_keys = [
-        [0] #<MongoMapper::Plugins::Keys::Key:0x01234567
+        [0] #<MongoMapper::Plugins::Keys::Key:placeholder_id
             @dynamic = false,
             @embeddable = false,
             @has_default = true,
@@ -55,7 +55,7 @@ RSpec.describe "AwesomePrint/MongoMapper", skip: ->{ !ExtVerifier.has_mongo_mapp
         >
     ],
     @__mm_keys = {
-               "_id" => #<MongoMapper::Plugins::Keys::Key:0x01234567
+               "_id" => #<MongoMapper::Plugins::Keys::Key:placeholder_id
             @dynamic = false,
             @embeddable = false,
             @has_default = true,
@@ -70,7 +70,7 @@ RSpec.describe "AwesomePrint/MongoMapper", skip: ->{ !ExtVerifier.has_mongo_mapp
             },
             attr_accessor :type = ObjectId < Object
         >,
-        "first_name" => #<MongoMapper::Plugins::Keys::Key:0x01234567
+        "first_name" => #<MongoMapper::Plugins::Keys::Key:placeholder_id
             @dynamic = false,
             @embeddable = false,
             @has_default = false,
@@ -82,7 +82,7 @@ RSpec.describe "AwesomePrint/MongoMapper", skip: ->{ !ExtVerifier.has_mongo_mapp
             attr_accessor :options = {},
             attr_accessor :type = String < Object
         >,
-         "last_name" => #<MongoMapper::Plugins::Keys::Key:0x01234567
+         "last_name" => #<MongoMapper::Plugins::Keys::Key:placeholder_id
             @dynamic = false,
             @embeddable = false,
             @has_default = false,
@@ -113,7 +113,7 @@ RSpec.describe "AwesomePrint/MongoMapper", skip: ->{ !ExtVerifier.has_mongo_mapp
         EOS
       else
         str = <<-EOS.strip
-#<MongoUser:0x01234567
+#<MongoUser:placeholder_id
     @_new = true,
     attr_accessor :first_name = "Al",
     attr_accessor :last_name = "Capone",
@@ -126,8 +126,7 @@ RSpec.describe "AwesomePrint/MongoMapper", skip: ->{ !ExtVerifier.has_mongo_mapp
 >
         EOS
       end
-      out.gsub!(/0x([a-f\d]+)/, "0x01234567")
-      expect(out).to eq(str)
+      expect(out).to be_similar_to(str)
     end
 
     it "should print the class" do
@@ -193,14 +192,12 @@ class Parent < Object {
         parent = Parent.new(:name => 'test')
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
-#<Parent:0x01234567> {
-     "_id" => BSON::ObjectId('4d9183739a546f6806000001'),
+#<Parent:placeholder_id> {
+     "_id" => placeholder_bison_id,
     "name" => "test"
 }
         EOS
-        out.gsub!(/'([\w]+){23}'/, "'4d9183739a546f6806000001'")
-        out.gsub!(/0x([a-f\d]+)/, "0x01234567")
-        expect(out).to eq(str)
+        expect(out).to be_similar_to(str)
       end
     end
 
@@ -224,16 +221,14 @@ class Parent < Object {
         parent = Parent.new(:name => 'test')
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
-#<Parent:0x01234567> {
-        "_id" => BSON::ObjectId('4d9183739a546f6806000001'),
+#<Parent:placeholder_id> {
+        "_id" => placeholder_bison_id,
        "name" => "test",
       "child" => embeds one Child,
     "sibling" => one Sibling
 }
         EOS
-        out.gsub!(/'([\w]+){23}'/, "'4d9183739a546f6806000001'")
-        out.gsub!(/0x([a-f\d]+)/, "0x01234567")
-        expect(out).to eq(str)
+        expect(out).to be_similar_to(str)
       end
     end
 
@@ -251,19 +246,17 @@ class Parent < Object {
         parent = Parent.new(:name => 'test', :child => Child.new(:data => 5))
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
-#<Parent:0x01234567> {
-        "_id" => BSON::ObjectId('4d9183739a546f6806000001'),
+#<Parent:placeholder_id> {
+        "_id" => placeholder_bison_id,
        "name" => "test",
-      "child" => embedded #<Child:0x01234567> {
-         "_id" => BSON::ObjectId('4d9183739a546f6806000001'),
+      "child" => embedded #<Child:placeholder_id> {
+         "_id" => placeholder_bison_id,
         "data" => 5
     },
     "sibling" => one Sibling
 }
         EOS
-        out.gsub!(/'([\w]+){23}'/, "'4d9183739a546f6806000001'")
-        out.gsub!(/0x([a-f\d]+)/, "0x01234567")
-        expect(out).to eq(str)
+        expect(out).to be_similar_to(str)
       end
     end
   end

--- a/spec/ext/mongo_mapper_spec.rb
+++ b/spec/ext/mongo_mapper_spec.rb
@@ -193,7 +193,7 @@ class Parent < Object {
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
 #<Parent:placeholder_id> {
-     "_id" => placeholder_bison_id,
+     "_id" => placeholder_bson_id,
     "name" => "test"
 }
         EOS
@@ -222,7 +222,7 @@ class Parent < Object {
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
 #<Parent:placeholder_id> {
-        "_id" => placeholder_bison_id,
+        "_id" => placeholder_bson_id,
        "name" => "test",
       "child" => embeds one Child,
     "sibling" => one Sibling
@@ -247,10 +247,10 @@ class Parent < Object {
         out = @ap.send(:awesome, parent)
         str = <<-EOS.strip
 #<Parent:placeholder_id> {
-        "_id" => placeholder_bison_id,
+        "_id" => placeholder_bson_id,
        "name" => "test",
       "child" => embedded #<Child:placeholder_id> {
-         "_id" => placeholder_bison_id,
+         "_id" => placeholder_bson_id,
         "data" => 5
     },
     "sibling" => one Sibling

--- a/spec/ext/mongoid_spec.rb
+++ b/spec/ext/mongoid_spec.rb
@@ -29,14 +29,13 @@ RSpec.describe "AwesomePrint/Mongoid", skip: ->{ !ExtVerifier.has_mongoid? }.cal
 
     object_id = user.id.inspect
     str = <<-EOS.strip
-#<MongoUser:0x01234567> {
+#<MongoUser:placeholder_id> {
            :_id => #{object_id},
     :first_name => "Al",
      :last_name => "Capone"
 }
     EOS
-    out.gsub!(/0x([a-f\d]+)/, "0x01234567")
-    expect(out).to eq(str)
+    expect(out).to be_similar_to(str)
   end
 
   it "should print the class" do

--- a/spec/ext/mongoid_spec.rb
+++ b/spec/ext/mongoid_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe "AwesomePrint/Mongoid", skip: ->{ !ExtVerifier.has_mongoid? }.cal
      :last_name => "Capone"
 }
     EOS
-    expect(out).to be_similar_to(str)
+    expect(out).to be_similar_to(str, {:skip_bson => true})
   end
 
   it "should print the class" do

--- a/spec/ext/ripple_spec.rb
+++ b/spec/ext/ripple_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe 'AwesomePrint/Ripple', skip: ->{ !ExtVerifier.has_ripple? }.call 
     user = RippleUser.new :_id => "12345", :first_name => "Al", :last_name => "Capone"
     out = @ap.send :awesome, user
 
-    expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq <<-EOS.strip
-#<RippleUser:0x01234567> {
+    expect(out).to be_similar_to <<-EOS.strip
+#<RippleUser:placeholder_id> {
            :_id => "12345",
     :first_name => "Al",
      :last_name => "Capone"

--- a/spec/objects_spec.rb
+++ b/spec/objects_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe "Objects" do
       hello = Hello.new
       out = hello.ai(:plain => true, :raw => true)
       str = <<-EOS.strip
-#<Hello:0x01234567
+#<Hello:placeholder_id
     attr_accessor :dabra = 3,
     attr_reader :abra = 1,
     attr_writer :ca = 2
 >
 EOS
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
       expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
     end
 
@@ -44,13 +44,13 @@ EOS
       hello = Hello.new
       out = hello.ai(:plain => true, :raw => true)
       str = <<-EOS.strip
-#<Hello:0x01234567
+#<Hello:placeholder_id
     @abra = 1,
     @ca = 2,
     @dabra = 3
 >
 EOS
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
       expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
     end
 
@@ -69,7 +69,7 @@ EOS
       hello = Hello.new
       out = hello.ai(:plain => true, :raw => true)
       str = <<-EOS.strip
-#<Hello:0x01234567
+#<Hello:placeholder_id
     @doo = 1,
     @dooby = 2,
     @scooby = 3,
@@ -78,7 +78,7 @@ EOS
     attr_writer :ca = 2
 >
 EOS
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
       expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
     end
 
@@ -96,13 +96,13 @@ EOS
       hello = Hello.new
       out = hello.ai(:raw => true)
       str = <<-EOS.strip
-#<Hello:0x01234567
+#<Hello:placeholder_id
     \e[0;36m@dabra\e[0m\e[0;37m = \e[0m\e[1;34m3\e[0m,
     \e[1;36mattr_reader\e[0m \e[0;35m:abra\e[0m\e[0;37m = \e[0m\e[1;34m1\e[0m,
     \e[1;36mattr_writer\e[0m \e[0;35m:ca\e[0m\e[0;37m = \e[0m\e[1;34m2\e[0m
 >
 EOS
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
       expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
     end
 
@@ -120,9 +120,9 @@ EOS
       hello = Hello.new
       out = hello.ai(:multiline => false, :plain => true, :raw => true)
       str = <<-EOS.strip
-#<Hello:0x01234567 @dabra = 3, attr_reader :abra = 1, attr_writer :ca = 2>
+#<Hello:placeholder_id @dabra = 3, attr_reader :abra = 1, attr_writer :ca = 2>
 EOS
-      expect(out.gsub(/0x([a-f\d]+)/, "0x01234567")).to eq(str)
+      expect(out).to be_similar_to(str)
       expect(hello.ai(:plain => true, :raw => false)).to eq(hello.inspect)
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,9 +51,10 @@ end
 # parts (such as object IDs) with simple placeholder strings before doing a
 # comparison with a given string. It's important that this method only matches
 # a string which strictly conforms to the expected object ID format.
-RSpec::Matchers.define :be_similar_to do |expected|
+RSpec::Matchers.define :be_similar_to do |expected, options|
   match do |actual|
-    @actual = normalize_object_strings(actual)
+    options ||= {}
+    @actual = normalize_object_id_strings(actual, options)
     values_match? expected, @actual
   end
 
@@ -63,8 +64,10 @@ end
 # Override the Object IDs with a placeholder so that we are only checking
 # that an ID is present and not that it matches a certain value. This is
 # necessary as the Object IDs are not deterministic.
-def normalize_object_strings(str)
-  str.gsub(/#<(.*?):0x[a-f\d]+/, '#<\1:placeholder_id')
+def normalize_object_id_strings(str, options)
+  str = str.gsub(/#<(.*?):0x[a-f\d]+/, '#<\1:placeholder_id') unless options[:skip_standard]
+  str = str.gsub(/BSON::ObjectId\('[a-f\d]{24}'\)/, 'placeholder_bson_id') unless options[:skip_bson]
+  str
 end
 
 def stub_dotfile!

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,26 @@ RSpec.configure do |config|
   end
 end
 
+# This matcher handles the normalization of objects to replace non deterministic
+# parts (such as object IDs) with simple placeholder strings before doing a
+# comparison with a given string. It's important that this method only matches
+# a string which strictly conforms to the expected object ID format.
+RSpec::Matchers.define :be_similar_to do |expected|
+  match do |actual|
+    @actual = normalize_object_strings(actual)
+    values_match? expected, @actual
+  end
+
+  diffable
+end
+
+# Override the Object IDs with a placeholder so that we are only checking
+# that an ID is present and not that it matches a certain value. This is
+# necessary as the Object IDs are not deterministic.
+def normalize_object_strings(str)
+  str.gsub(/#<(.*?):0x[a-f\d]+/, '#<\1:placeholder_id')
+end
+
 def stub_dotfile!
   dotfile = File.join(ENV["HOME"], ".aprc")
   expect(File).to receive(:readable?).at_least(:once).with(dotfile).and_return(false)


### PR DESCRIPTION
This fixes broken tests for ActiveRecord in Rails 4.2 by updating them to expect format currently used by Rails 4.2. During this process I also simplified some of the tests by introducing a new Rspec matcher which does a lot of the heavy lifting which was previous spread throughout the testing code but unrelated to what we were actually testing.